### PR TITLE
[class_list_macros.h: No such file fix] CMakeLists.txt include header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ catkin_package(
 ###########
 
 ## Specify additional locations of header files
-# include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 ## Declare a cpp library
  add_library(camera_throttler_nodelets


### PR DESCRIPTION
Fixes: `fatal error: pluginlib/class_list_macros.h: No such file or directory` when building with catkin build on Melodic