### PR TITLE
[Failed to load nodelet fix] Added plugin names

### DIFF
--- a/plugin_description.xml
+++ b/plugin_description.xml
@@ -1,17 +1,17 @@
 <library path="lib/libcamera_throttler_nodelets">
-  <class type="camera_throttle_nodelets::NodeletThrottleCompressedImage" base_class_type="nodelet::Nodelet">
+  <class name="camera_throttle_nodelets/NodeletThrottleCompressedImage" type="camera_throttle_nodelets::NodeletThrottleCompressedImage" base_class_type="nodelet::Nodelet">
     <description>This is a compressed image throttling plugin.</description>
   </class>
-  <class type="camera_throttle_nodelets::NodeletThrottleParameterDescription" base_class_type="nodelet::Nodelet">
+  <class name="camera_throttle_nodelets/NodeletThrottleParameterDescription" type="camera_throttle_nodelets::NodeletThrottleParameterDescription" base_class_type="nodelet::Nodelet">
     <description>This is a sensor message parameter description throttling plugin.</description>
   </class>
-  <class type="camera_throttle_nodelets::NodeletThrottleParameterUpdates" base_class_type="nodelet::Nodelet">
+  <class name="camera_throttle_nodelets/NodeletThrottleParameterUpdates" type="camera_throttle_nodelets::NodeletThrottleParameterUpdates" base_class_type="nodelet::Nodelet">
   <description>This is a sensor message parameter update throttling plugin.</description>
   </class>
-  <class type="camera_throttle_nodelets::NodeletThrottleCameraInfo" base_class_type="nodelet::Nodelet">
+  <class name="camera_throttle_nodelets/NodeletThrottleCameraInfo" type="camera_throttle_nodelets::NodeletThrottleCameraInfo" base_class_type="nodelet::Nodelet">
     <description>This is a compressed image throttling plugin.</description>
   </class>
-  <class type="camera_throttle_nodelets::NodeletThrottleImage" base_class_type="nodelet::Nodelet">
+  <class name="camera_throttle_nodelets/NodeletThrottleImage" type="camera_throttle_nodelets::NodeletThrottleImage" base_class_type="nodelet::Nodelet">
     <description>This is an image throttling plugin.</description>
   </class>
 </library>


### PR DESCRIPTION
Fixes
```
Failed to load nodelet [/data_throttle] of type [camera_throttle_nodelets/NodeletThrottleImage] even after refreshing the cache: According to the loaded plugin descriptions the class camera_throttle_nodelets/NodeletThrottleImage with base class type nodelet::Nodelet does not exist.
```